### PR TITLE
change to ensure generating a new random id

### DIFF
--- a/lib/humanizer.rb
+++ b/lib/humanizer.rb
@@ -8,18 +8,26 @@ module Humanizer
   attr_writer :humanizer_question_id
 
   def humanizer_question
-    humanizer_questions[humanizer_question_id.to_i]["question"]
+    humanizer_questions[humanizer_question_id]["question"]
   end
   
   def humanizer_question_id
-    @humanizer_question_id ||= Kernel.rand(humanizer_questions.count)
+    @humanizer_question_id ||= change_humanizer_question_id
   end
   
+  def generate_random_question_id(current = -1)
+    change_humanizer_question_id until current.to_i != humanizer_question_id
+  end
+    
   def humanizer_correct_answer?
     humanizer_answer && humanizer_answers_for_id(humanizer_question_id).include?(humanizer_answer.downcase)
   end
 
   private
+  
+  def change_humanizer_question_id
+    @humanizer_question_id = Kernel.rand(humanizer_questions.count).to_i
+  end
   
   def humanizer_questions
     @humanizer_questions ||= I18n.translate("humanizer.questions")

--- a/spec/humanizer_spec.rb
+++ b/spec/humanizer_spec.rb
@@ -90,4 +90,26 @@ describe Humanizer do
     
   end
   
+  context "generate_random_question_id" do
+    
+    it "sets humanizer_question_id with no params" do
+      @user.generate_random_question_id
+      @user.instance_variable_get(:@humanizer_question_id).should_not be_nil
+    end
+    context 'when passing in a value' do
+      before do
+        # return 5 for humanizer question id the first and second time
+        @user.should_receive(:humanizer_question_id).and_return(5)
+        @user.should_receive(:humanizer_question_id).and_return(5)        
+        # return 6(a different value) for humanizer question id the third time
+        @user.should_receive(:humanizer_question_id).and_return(6)
+        # ensure that change humanizer question id was called twice
+        @user.should_receive(:change_humanizer_question_id).twice
+        
+      end
+      it "sets humanizer_question_id to a new value" do
+        @user.generate_random_question_id(5)
+      end
+    end
+  end
 end


### PR DESCRIPTION
We have a project in which we are using Humanizer and our customer requested the ability to request a new humanizer question.  We basically made a controller that returns the humanizer question text and input field that looks something like this:

route looks like '/captchas?current_question_id=5'

```
class CaptchasController < ApplicationController
  include Humanizer
  layout false
  def show
    begin
      @question_id = humanizer_question_id
      @question = humanizer_question
      humanizer_question_id = nil
    end until ( @question_id.to_i != params[:current_question_id].to_i )
  end
end
```

Granted this code isn't the cleanest and I don't agree with it 100% but the basic idea was to create a loop that guaranteed a new question that isn't the current question.

Based on the way humanizer works this code essentially creates a local variable named humanizer_question_id which hides the humanizer_question_id method.  

Due to the humanizer_question_id almost always returning us a different question id than the parameter passed to the controller, the bug we introduced has been hidden from us for at least 2 months now.

The fix for this is really simple, given the code we have just change it to:

```
begin
  @humanizer_question_id = nil
  @question_id = humanizer_question_id
  @question = humanizer_question

end until ( @question_id.to_i != params[:current_question_id].to_i )
```

Personally I really don't think that anything should be using the @humanizer_question_id variable.  I would like to change humanizer to look like this:

```
def humanizer_question_id
  @humanizer_question_id ||= reset_humanizer_question_id
end

def generate_random_question_id(current = nil)
  @humanizer_question_id = reset_humanizer_question_id until current.try(:to_i) != @humanizer_question_id
end

private
def reset_humanizer_question_id
  Kernel.rand(humanizer_questions.count).to_i
end
```

This wouldn't change any of the current functionality, the only real difference is that I'm exposing a method that I can pass a current number or string(or pass nothing) and it will set @humanizer_question_id to a different value than what is passed in, and then just extracting the Kernel.rand to a method.  

I've submitted a pull request, but wanted to put in an issue to explain why I changed the code.

Any thoughts at all?
