### PR TITLE
Introduced a bug by changing this.

### DIFF
--- a/lib/humanizer.rb
+++ b/lib/humanizer.rb
@@ -8,7 +8,7 @@ module Humanizer
   attr_writer :humanizer_question_id
 
   def humanizer_question
-    humanizer_questions[humanizer_question_id]["question"]
+    humanizer_questions[humanizer_question_id.to_i]["question"]
   end
   
   def humanizer_question_id


### PR DESCRIPTION
I introduced a bug with the patch I committed.  

By not changing the humanizer_question_id to an integer when calling humanizer_question it blows up saying can't convert String into Integer.

For us the use case is if a user is enrolling and they submit the page with an error, when the enrollment template is being rendered with the errors it asks humanizer for the question again.  Since the humanizer_question_id was set on the user via the parameters the humanizer_question_id is a String not an Integer.
