### PR TITLE
Adds stringify_keys on humanizer_questions

### DIFF
--- a/lib/humanizer.rb
+++ b/lib/humanizer.rb
@@ -8,7 +8,7 @@ module Humanizer
   attr_writer :humanizer_question_id
 
   def humanizer_question
-    humanizer_questions[humanizer_question_id.to_i]["question"]
+    humanizer_questions[humanizer_question_id.to_i].stringify_keys["question"]
   end
   
   def humanizer_question_id
@@ -40,7 +40,7 @@ module Humanizer
   end
 
   def humanizer_answers_for_id(id)
-    question = humanizer_questions[id.to_i]
+    question = humanizer_questions[id.to_i].stringify_keys
     Array(question["answer"] || question["answers"]).map { |a| a.to_s.mb_chars.downcase }
   end
 


### PR DESCRIPTION
The gem is not working for me because the humanizer_questions are hashes whose keys are symbols but the gem is using strings.

I suspect this is related to my version of ruby (1.8.7-p371), but it doesn't hurt to explicitely state which kind of keys to expect.

What do you think ?
