### PR TITLE
Use Array#sample

### DIFF
--- a/lib/humanizer.rb
+++ b/lib/humanizer.rb
@@ -49,7 +49,7 @@ module Humanizer
   end
 
   def random_humanizer_question_id
-    humanizer_question_ids[rand(humanizer_question_ids.count)]
+    humanizer_question_ids.sample
   end
 
   def humanizer_answers_for_id(id)


### PR DESCRIPTION
Ruby's `Array` class has a builtin `#sample()` method to pick a random element in an array.

It seems more idiomatic to use it instead of an home-made version.
But maybe there is a good reason that I don't know ;)