### PR TITLE
fix: modify private method to not mutate hash

### DIFF
--- a/lib/humanizer.rb
+++ b/lib/humanizer.rb
@@ -32,14 +32,15 @@ module Humanizer
       questions = I18n.translate!("humanizer.questions")
       # Poor man's HashWithIndifferentAccess
       questions.map do |question|
-        question.default_proc = proc do |h, k|
-           case k
-             when String then sym = k.to_sym; h[sym] if h.key?(sym)
-             when Symbol then str = k.to_s; h[str] if h.key?(str)
-           end
+        config = Hash.new
+        config.default_proc = proc do |h, k|
+          case k
+            when String then sym = k.to_sym; h[sym] if h.key?(sym)
+            when Symbol then str = k.to_s; h[str] if h.key?(str)
+          end
         end
+        config.merge(question)
       end
-      questions
     end
   end
 


### PR DESCRIPTION
fixes #54  `can't modify frozen Hash` 

On master, ruby-2.7.2: 17 examples, 9 failures...

![Screen Shot 2022-04-25 at 11 25 41 AM](https://user-images.githubusercontent.com/1447940/165150985-97d6a7ca-beff-46c9-8ed2-556a56104c23.png)